### PR TITLE
Breaking Change: Increase similarity with Python standard library json module behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Releases
 
+- **Breaking Change:** Increase similarity with Python standard library json module behavior:
+  1. Now `load` and `load_archive` accept `cls` and `**kwargs` for custom decoding instead of `json_loads` and `**json_loads_kwargs`
+  2. Now `dump`, `dump_fork`, `dumps` and `dump_archive` accept `cls` and `**kwargs` for custom encoding instead of `json_dumps` and `**json_dumps_kwargs`
+
 ### v1.3.27 (2026-06-16)
 
 - **Added:** Support for compression.zstd (Python 3.14+)

--- a/README.md
+++ b/README.md
@@ -169,8 +169,10 @@ For complete parameter documentation, see the [full docs →](https://rmoralespp
 
 ## Custom Serialization
 
-Plug in any JSON-compatible serializer. For example, [`orjson`](https://github.com/ijl/orjson)
-for high-performance encoding:
+Plug in any JSON-compatible serializer.
+
+
+For example, [`orjson`](https://github.com/ijl/orjson) for high-performance encoding:
 
 ```python
 import orjson  # ensure orjson is installed: pip install orjson
@@ -179,14 +181,53 @@ import jsonl
 data = [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
 
 # Write with orjson (returns bytes → set text_mode=False)
-jsonl.dump(data, "fast.jsonl", json_dumps=orjson.dumps, text_mode=False)
+jsonl.dump(data, "fast.jsonl", text_mode=False, cls=orjson.dumps)
 
 # Read with orjson
-for item in jsonl.load("fast.jsonl", json_loads=orjson.loads):
+for item in jsonl.load("fast.jsonl", cls=orjson.loads):
     print(item)
 ```
 
-Extra keyword arguments are forwarded to the underlying serializer:
+Another example: using custom `JSONEncoder` or `JSONDecoder` with `**kwargs` for various purposes, for example:
+
+
+```python
+import datetime
+import decimal
+import json
+
+import jsonl
+
+
+class UpperDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, object_hook=self.object_hook, parse_float=decimal.Decimal, **kwargs)
+
+    def object_hook(self, obj):
+        return {k.upper(): v for k, v in obj.items()}
+
+
+class ISODateEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.date):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+data = [
+    {"name": "Alice", "birthdate": datetime.date(2000, 1, 1)},
+    {"name": "Bob", "birthdate": datetime.date(2005, 1, 1)}
+]
+
+#  Write using a custom encoder to serialize datetime objects as ISO strings
+jsonl.dump(data, "fast.jsonl", cls=ISODateEncoder)
+
+# Read using a custom decoder to convert floats into Decimal and uppercase all keys
+for item in jsonl.load("fast.jsonl", cls=UpperDecoder):
+    print(item)
+```
+
+keyword arguments are forwarded to the underlying serializer:
 
 ```python
 import jsonl

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ specifications.
 
 ## Features
 
-| Feature                        | Description                                                                                                     |
-|--------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| 🌎 **Familiar API**            | Interface similar to the standard `json` module (`dump`, `load`, `dumps`)                                       |
-| ⚡ **Streaming by default**     | Read and write incrementally via iterators, keeping memory usage low                                            |
-| 🗜️ **Built-in compression**   | Transparent support for `gzip`, `bzip2`, `xz`, and `zst` (Python ≥ 3.14)                                        |
-| 📦 **Archive support**         | Read and write `ZIP` and `TAR` archives (`.tar.gz`, `.tar.bz2`, `.tar.xz`, and `.tar.zst` **(Python ≥ 3.14) )** |
-| 📥 **Load from URLs**          | Pass a URL directly to `load()` or `load_archive()`                                                             |
-| 🚀 **Pluggable serialization** | Swap in [`orjson`](https://github.com/ijl/orjson), or any JSON library                                          |
-| 🔧 **Error tolerance**         | Optionally skip malformed lines instead of crashing                                                             |
-| 🐍 **Zero dependencies**       | Uses only the Python standard library — nothing else                                                            |
+| Feature                        | Description                                                                                                 |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------|
+| 🌎 **Familiar API**            | Interface similar to the standard `json` module (`dump`, `load`, `dumps`)                                   |
+| ⚡ **Streaming by default**     | Read and write incrementally via **iterators**, keeping memory usage low                                    |
+| 🗜️ **Built-in compression**   | Transparent support for `gzip`, `bzip2`, `xz`, and `zst` (Python ≥ 3.14)                                    |
+| 📦 **Archive support**         | Read and write `ZIP` and `TAR` archives (`.tar.gz`, `.tar.bz2`, `.tar.xz`, and `.tar.zst` (Python ≥ 3.14) ) |
+| 📥 **Load from URLs**          | Pass a URL directly to `load()` or `load_archive()`                                                         |
+| 🚀 **Pluggable serialization** | Swap in [`orjson`](https://github.com/ijl/orjson), or any JSON library                                      |
+| 🔧 **Error tolerance**         | Optionally skip malformed lines instead of crashing                                                         |
+| 🐍 **Zero dependencies**       | Uses only the Python standard library — nothing else                                                        |
 
 ## Installation
 
@@ -150,7 +150,7 @@ jsonl.dump_fork(data)
 | `jsonl.loader(stream, broken, **kw)` | Low-level generator deserializing a line stream   |
 
 > [!TIP]
-> All **read** functions accept `json_loads` and `**json_loads_kwargs` for custom deserialization.
+> All **read** functions accept `cls` and `**kwargs` for custom decoding.
 
 ### Writing
 
@@ -163,14 +163,13 @@ jsonl.dump_fork(data)
 | `jsonl.dumper(iterable, **kw)`         | Low-level generator yielding formatted lines             |
 
 > [!TIP]
-> All **write** functions accept `json_dumps` and `**json_dumps_kwargs` for custom serialization.
+> All **write** functions accept `cls` and `**kwargs` for custom encoding.
 
 For complete parameter documentation, see the [full docs →](https://rmoralespp.github.io/jsonl/)
 
 ## Custom Serialization
 
 Plug in any JSON-compatible serializer.
-
 
 For example, [`orjson`](https://github.com/ijl/orjson) for high-performance encoding:
 
@@ -188,8 +187,7 @@ for item in jsonl.load("fast.jsonl", cls=orjson.loads):
     print(item)
 ```
 
-Another example: using custom `JSONEncoder` or `JSONDecoder` with `**kwargs` for various purposes, for example:
-
+Another example: using custom `cls` with `**kwargs` for various purposes, for example:
 
 ```python
 import datetime
@@ -220,10 +218,10 @@ data = [
 ]
 
 #  Write using a custom encoder to serialize datetime objects as ISO strings
-jsonl.dump(data, "fast.jsonl", cls=ISODateEncoder)
+jsonl.dump(data, "file.jsonl", cls=ISODateEncoder)
 
 # Read using a custom decoder to convert floats into Decimal and uppercase all keys
-for item in jsonl.load("fast.jsonl", cls=UpperDecoder):
+for item in jsonl.load("file.jsonl", cls=UpperDecoder):
     print(item)
 ```
 
@@ -258,8 +256,8 @@ jsonl.dump(data, "sorted.jsonl", sort_keys=True)  # deterministic keys
 pip install --group=test --upgrade
 
 # Run tests
-python -m pytest tests/
-python -m pytest tests/ --cov  # run with coverage reporting
+python -Wd -m pytest tests/
+python -Wd -m pytest tests/ --cov  # run with coverage reporting
 
 # Lint
 pip install --group=lint --upgrade

--- a/docs/dump.md
+++ b/docs/dump.md
@@ -1,6 +1,6 @@
 # jsonl.dump
 
-Write an iterable of objects to a JSON Lines file. Supports filenames (with automatic compression),
+Write an iterable of objects to a JSON Lines file. Supports filenames *(with automatic compression)*,
 `os.PathLike` objects, and file-like objects with `write` or `writelines` methods.
 
 ## Function Signature
@@ -12,32 +12,32 @@ jsonl.dump(
     *,
     opener=None,
     text_mode=True,
-    json_dumps=None,
-    **json_dumps_kwargs,
+    cls=None,
+    **kwargs,
 )
 ```
 
 ### Parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `iterable` | `Iterable[Any]` | *(required)* | Iterable of JSON-serializable objects |
-| `file` | `str`, `PathLike`, file-like | *(required)* | Destination file path or file-like object |
-| `opener` | `Callable` or `None` | `None` | Custom function to open the file (used only when `file` is a path) |
-| `text_mode` | `bool` | `True` | If `False`, write bytes instead of text |
-| `json_dumps` | `Callable` or `None` | `None` | Custom serialization function. Defaults to `json.dumps` |
-| `**json_dumps_kwargs` | | | Additional keyword arguments passed to the serialization function |
+| Parameter    | Type                                          | Default            | Description                                                        |
+|--------------|-----------------------------------------------|--------------------|--------------------------------------------------------------------|
+| `iterable`   | `Iterable[Any]`                               | *(required)*       | Iterable of JSON-serializable objects                              |
+| `file`       | `str`, `PathLike`, file-like                  | *(required)*       | Destination file path or file-like object                          |
+| `opener`     | `Callable` or `None`                          | `None`             | Custom function to open the file (used only when `file` is a path) |
+| `text_mode`  | `bool`                                        | `True`             | If `False`, write bytes instead of text                            |
+| `cls`        | `type[json.JSONEncoder]` `Callable` or `None` | `json.JSONEncoder` | Custom encoder                                                     |
+| `**kwargs`   |                                               |                    | Additional keyword arguments passed to the `cls` encoder           |
 
 ### Raises
 
-| Exception | Condition |
-|---|---|
+| Exception    | Condition                                                           |
+|--------------|---------------------------------------------------------------------|
 | `ValueError` | If the file object is missing both `writelines` and `write` methods |
 
 ### Compression Detection
 
 !!! note
-    Supported compression formats: **gzip (.gz), bzip2 (.bz2), xz (.xz), zst (.zst) (Python ≥ 3.14) **
+    Supported compression formats: `.gz`, `.bz2`, `.xz`, `.zst` (Python ≥ 3.14)
 
     When a filename is provided, the compression format is determined by its extension.
     If the extension is not recognized, the file is written as plain text.
@@ -69,10 +69,10 @@ data = [
     {"name": "May", "wins": []},
 ]
 
-jsonl.dump(data, "file.jsonl.gz")    # gzip
-jsonl.dump(data, "file.jsonl.bz2")   # bzip2
-jsonl.dump(data, "file.jsonl.xz")    # xz
-jsonl.dump(data, "file.jsonl.zst")    # zst
+jsonl.dump(data, "file.jsonl.gz")  # gzip
+jsonl.dump(data, "file.jsonl.bz2")  # bzip2
+jsonl.dump(data, "file.jsonl.xz")  # xz
+jsonl.dump(data, "file.jsonl.zst")  # zst
 ```
 
 ### Write to an open file object
@@ -142,6 +142,31 @@ jsonl.dump(data, MyWriter(), text_mode=True)
 
 ### Custom serialization
 
+#### Using custom JSON Encoder
+
+```python
+import datetime
+import json
+
+import jsonl
+
+
+class ISODateEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.date):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+data = [
+    {"name": "Alice", "birthdate": datetime.date(2000, 1, 1)},
+    {"name": "Bob", "birthdate": datetime.date(2005, 1, 1)}
+]
+
+#  Write using a custom encoder to serialize datetime objects as ISO strings
+jsonl.dump(data, "file.jsonl", cls=ISODateEncoder)
+```
+
 #### Using a third-party library
 
 [`orjson`](https://github.com/ijl/orjson) is a high-performance JSON library that returns bytes:
@@ -156,12 +181,12 @@ data = [
 ]
 
 # orjson returns bytes — set text_mode=False
-jsonl.dump(data, "file.jsonl", json_dumps=orjson.dumps, text_mode=False)
+jsonl.dump(data, "file.jsonl", cls=orjson.dumps, text_mode=False)
 ```
 
-#### Passing additional keyword arguments
+#### Passing keyword arguments
 
-Extra keyword arguments are forwarded directly to the serialization function (by default, `json.dumps`):
+Extra keyword arguments are forwarded directly to the `cls` decoder:
 
 ```python
 import jsonl

--- a/docs/dump_archive.md
+++ b/docs/dump_archive.md
@@ -13,22 +13,22 @@ jsonl.dump_archive(
     opener=None,
     text_mode=True,
     dump_if_empty=True,
-    json_dumps=None,
-    **json_dumps_kwargs,
+    cls=None,
+    **kwargs,
 )
 ```
 
 ### Parameters
 
-| Parameter             | Type                                  | Default      | Description                                                       |
-|-----------------------|---------------------------------------|--------------|-------------------------------------------------------------------|
-| `path`                | `str`                                 | *(required)* | Destination path for the archive file                             |
-| `data`                | `Iterable[tuple[str, Iterable[Any]]]` | *(required)* | Iterable of `(relative_path, items)` tuples                       |
-| `opener`              | `Callable` or `None`                  | `None`       | Custom function to open the given file paths                      |
-| `text_mode`           | `bool`                                | `True`       | If `False`, write bytes instead of text                           |
-| `dump_if_empty`       | `bool`                                | `True`       | If `False`, don't create empty files or an empty archive          |
-| `json_dumps`          | `Callable` or `None`                  | `None`       | Custom serialization function. Defaults to `json.dumps`           |
-| `**json_dumps_kwargs` |                                       |              | Additional keyword arguments passed to the serialization function |
+| Parameter       | Type                                          | Default            | Description                                               |
+|-----------------|-----------------------------------------------|--------------------|-----------------------------------------------------------|
+| `path`          | `str`                                         | *(required)*       | Destination path for the archive file                     |
+| `data`          | `Iterable[tuple[str, Iterable[Any]]]`         | *(required)*       | Iterable of `(relative_path, items)` tuples               |
+| `opener`        | `Callable` or `None`                          | `None`             | Custom function to open the given file paths              |
+| `text_mode`     | `bool`                                        | `True`             | If `False`, write bytes instead of text                   |
+| `dump_if_empty` | `bool`                                        | `True`             | If `False`, don't create empty files or an empty archive  |
+| `cls`           | `type[json.JSONEncoder]` `Callable` or `None` | `json.JSONEncoder` | Custom encoder                                            |
+| `**kwargs`      |                                               |                    | Additional keyword arguments passed to the `cls`  encoder |
 
 ### Returns
 
@@ -46,12 +46,12 @@ jsonl.dump_archive(
 | `.tar.zst` | TAR + zst (Python ≥ 3.14) |
 
 !!! warning
-If the archive already exists at the given path, it will be **overwritten**.
+    If the archive already exists at the given path, it will be **overwritten**.
 
 !!! note
-- Paths in the `data` argument must be **relative**. Absolute paths will raise a `ValueError`.
-- If `data` contains multiple items for the same path, they are **appended** to the corresponding file within the
-archive.
+    - Paths in the `data` argument must be **relative**. Absolute paths will raise a `ValueError`.
+    - If `data` contains multiple items for the same path, they are **appended** to the corresponding file within the
+      archive.
 
 ---
 

--- a/docs/dump_fork.md
+++ b/docs/dump_fork.md
@@ -12,26 +12,27 @@ jsonl.dump_fork(
     opener=None,
     text_mode=True,
     dump_if_empty=True,
-    json_dumps=None,
-    **json_dumps_kwargs,
+    cls=None,
+    **kwargs,
 )
 ```
 
 ### Parameters
 
-| Parameter             | Type                                  | Default      | Description                                                       |
-|-----------------------|---------------------------------------|--------------|-------------------------------------------------------------------|
-| `paths`               | `Iterable[tuple[str, Iterable[Any]]]` | *(required)* | Iterable of `(filepath, items)` tuples                            |
-| `opener`              | `Callable` or `None`                  | `None`       | Custom function to open the given file paths                      |
-| `text_mode`           | `bool`                                | `True`       | If `False`, write bytes instead of text                           |
-| `dump_if_empty`       | `bool`                                | `True`       | If `False`, don't create empty files                              |
-| `json_dumps`          | `Callable` or `None`                  | `None`       | Custom serialization function. Defaults to `json.dumps`           |
-| `**json_dumps_kwargs` |                                       |              | Additional keyword arguments passed to the serialization function |
+| Parameter       | Type                                          | Default            | Description                                               |
+|-----------------|-----------------------------------------------|--------------------|-----------------------------------------------------------|
+| `paths`         | `Iterable[tuple[str, Iterable[Any]]]`         | *(required)*       | Iterable of `(filepath, items)` tuples                    |
+| `opener`        | `Callable` or `None`                          | `None`             | Custom function to open the given file paths              |
+| `text_mode`     | `bool`                                        | `True`             | If `False`, write bytes instead of text                   |
+| `dump_if_empty` | `bool`                                        | `True`             | If `False`, don't create empty files                      |
+| `cls`           | `type[json.JSONEncoder]` `Callable` or `None` | `json.JSONEncoder` | Custom encoder                                            |
+| `**kwargs`      |                                               |                    | Additional keyword arguments passed to the `cls`  encoder |
 
 ### Behavior
 
 - If the same filepath appears multiple times, subsequent data is **appended** to the file.
-- Files can use compression extensions (`.gz`, `.bz2`, `.xz`, `.zst` (Python ≥ 3.14) ) and will be compressed accordingly.
+- Files can use compression extensions (`.gz`, `.bz2`, `.xz`, and `.zst` *Python ≥ 3.14* ) and will be compressed
+  accordingly.
 - When `dump_if_empty=False`, files with no data are not created.
 
 ---
@@ -88,5 +89,5 @@ def worker():
 
 
 # Using orjson for faster serialization
-jsonl.dump_fork(worker(), json_dumps=orjson.dumps, text_mode=False)
+jsonl.dump_fork(worker(), cls=orjson.dumps, text_mode=False)
 ```

--- a/docs/dumps.md
+++ b/docs/dumps.md
@@ -8,18 +8,18 @@ Serialize an iterable of objects into a JSON Lines formatted string.
 jsonl.dumps(
     iterable,
     *,
-    json_dumps=None,
-    **json_dumps_kwargs,
+    cls=None,
+    **kwargs,
 )
 ```
 
 ### Parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `iterable` | `Iterable[Any]` | *(required)* | Iterable of objects to serialize |
-| `json_dumps` | `Callable` or `None` | `None` | Custom serialization function. Defaults to `json.dumps` |
-| `**json_dumps_kwargs` | | | Additional keyword arguments passed to the serialization function |
+| Parameter  | Type                                          | Default            | Description                                               |
+|------------|-----------------------------------------------|--------------------|-----------------------------------------------------------|
+| `iterable` | `Iterable[Any]`                               | *(required)*       | Iterable of objects to serialize                          |
+| `cls`      | `type[json.JSONEncoder]` `Callable` or `None` | `json.JSONEncoder` | Custom encoder                                            |
+| `**kwargs` |                                               |                    | Additional keyword arguments passed to the `cls`  encoder |
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # jsonl
 
 <p align="center">
-  <em>A lightweight, dependency-free Python library for reading, writing, and streaming JSON Lines data.</em>
+  <em>A lightweight, dependency-free Python library for JSON Lines — read, write, compress, and stream with ease.</em>
 </p>
 
 <p align="center">
@@ -26,22 +26,22 @@ specifications.
 
 ## Why jsonl?
 
-The [JSON Lines](https://jsonlines.org/) format is ideal for processing large volumes of structured data line by line,
-without loading everything into memory. **jsonl** lets you work with this format effortlessly, offering a familiar API
+The [JSON Lines](https://jsonlines.org/) format is ideal for processing **large volumes** of structured data **line by line**,
+without loading everything into memory. `jsonl` lets you work with this format effortlessly, offering a familiar API
 inspired by Python's standard `json` module — with zero external dependencies.
 
 ## Features
 
-| Feature                        | Description                                                                                                     |
-|--------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| 🌎 **Familiar API**            | Interface similar to the standard `json` module (`dump`, `load`, `dumps`)                                       |
-| ⚡ **Streaming by default**     | Read and write incrementally via iterators, keeping memory usage low                                            |
-| 🗜️ **Built-in compression**   | Transparent support for `gzip`, `bzip2`, `xz`, and `zst` (Python ≥ 3.14)                                        |
-| 📦 **Archive support**         | Read and write `ZIP` and `TAR` archives (`.tar.gz`, `.tar.bz2`, `.tar.xz`, and `.tar.zst` **(Python ≥ 3.14)** ) |
-| 📥 **Load from URLs**          | Pass a URL directly to `load()` or `load_archive()`                                                             |
-| 🚀 **Pluggable serialization** | Swap in [`orjson`](https://github.com/ijl/orjson), or any JSON library                                          |
-| 🔧 **Error tolerance**         | Optionally skip malformed lines instead of crashing                                                             |
-| 🐍 **Zero dependencies**       | Uses only the Python standard library — nothing else                                                            |
+| Feature                        | Description                                                                                                 |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------|
+| 🌎 **Familiar API**            | Interface similar to the standard `json` module (`dump`, `load`, `dumps`)                                   |
+| ⚡ **Streaming by default**     | Read and write incrementally via **iterators**, keeping memory usage low                                    |
+| 🗜️ **Built-in compression**   | Transparent support for `gzip`, `bzip2`, `xz`, and `zst` (Python ≥ 3.14)                                    |
+| 📦 **Archive support**         | Read and write `ZIP` and `TAR` archives (`.tar.gz`, `.tar.bz2`, `.tar.xz`, and `.tar.zst` (Python ≥ 3.14) ) |
+| 📥 **Load from URLs**          | Pass a URL directly to `load()` or `load_archive()`                                                         |
+| 🚀 **Pluggable serialization** | Swap in [`orjson`](https://github.com/ijl/orjson), or any JSON library                                      |
+| 🔧 **Error tolerance**         | Optionally skip malformed lines instead of crashing                                                         |
+| 🐍 **Zero dependencies**       | Uses only the Python standard library — nothing else                                                        |
 
 ## Quick Start
 
@@ -52,12 +52,13 @@ pip install py-jsonl
 ```
 
 !!! note
-Requires **Python 3.8** or higher. No external dependencies needed.
+    Requires **Python 3.8** or higher. No external dependencies needed.
 
 ### Write data
 
 ```python
 import jsonl
+
 
 data = [
     {"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]},
@@ -72,6 +73,7 @@ jsonl.dump(data, "players.jsonl")
 ```python
 import jsonl
 
+
 for item in jsonl.load("players.jsonl"):
     print(item)
 ```
@@ -80,6 +82,7 @@ for item in jsonl.load("players.jsonl"):
 
 ```python
 import jsonl
+
 
 for item in jsonl.load("https://example.com/data.jsonl"):
     print(item)
@@ -93,6 +96,7 @@ if the file extension is not recognized:
 
 ```python
 import jsonl
+
 
 data = [{"key": "value"}]
 
@@ -109,6 +113,7 @@ for item in jsonl.load("file.jsonl.gz"):
 
 ```python
 import jsonl
+
 
 # Write multiple files into an archive
 data = [
@@ -136,7 +141,7 @@ for filename, items in jsonl.load_archive("data.tar.gz"):
 | [`jsonl.load_archive`](load_archive.md) | Read JSON Lines files from a ZIP or TAR archive                 |
 
 !!! tip "Custom Serialization"
-All **read** functions accept `json_loads` and `**json_loads_kwargs` for custom deserialization.
+    All **read** functions accept `json_loads` and `**json_loads_kwargs` for custom deserialization.
 
 ### Writing
 
@@ -148,7 +153,10 @@ All **read** functions accept `json_loads` and `**json_loads_kwargs` for custom 
 | [`jsonl.dump_archive`](dump_archive.md) | Pack multiple JSON Lines files into a ZIP or TAR archive |
 
 !!! tip "Custom Serialization"
-All **write** functions accept `json_dumps` and `**json_dumps_kwargs` for custom serialization.
+    All **write** functions accept `cls` and `**kwargs` for custom serialization.
+
+    The `cls` specifies a custom JSON encoder class (default: `json.JSONEncoder`), while any additional keyword args 
+    are passed directly to the encoder.
 
 ## Supported Formats
 
@@ -160,9 +168,9 @@ All **write** functions accept `json_dumps` and `**json_dumps_kwargs` for custom
 | TAR archive | `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst` (Python ≥ 3.14) |
 
 !!! info
-When reading, if the file extension is not recognized, **jsonl** falls back to
-[magic-number detection](https://en.wikipedia.org/wiki/List_of_file_signatures)
-to identify the compression format automatically.
+    When reading, if the file extension is not recognized, **jsonl** falls back to
+    [magic-number detection](https://en.wikipedia.org/wiki/List_of_file_signatures)
+    to identify the compression format automatically.
 
 ## License
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ pip install py-jsonl --upgrade
 ## Optional: High-Performance JSON Libraries
 
 **jsonl** works with the standard `json` module out of the box. For better performance, you can use
-alternative JSON libraries by passing them via the `json_dumps` / `json_loads` parameters:
+alternative JSON libraries by passing them via the `cls` parameter:
 
 ```bash
 pip install orjson
@@ -33,9 +33,9 @@ import jsonl
 data = [{"name": "Alice"}, {"name": "Bob"}]
 
 # Write using orjson (returns bytes, use text_mode=False)
-jsonl.dump(data, "file.jsonl", json_dumps=orjson.dumps, text_mode=False)
+jsonl.dump(data, "file.jsonl", cls=orjson.dumps, text_mode=False)
 
 # Read using orjson
-for item in jsonl.load("file.jsonl", json_loads=orjson.loads):
+for item in jsonl.load("file.jsonl", cls=orjson.loads):
     print(item)
 ```

--- a/docs/load.md
+++ b/docs/load.md
@@ -6,25 +6,18 @@ Deserialize a JSON Lines source into an iterator of Python objects. Supports fil
 ## Function Signature
 
 ```python
-jsonl.load(
-    source,
-    *,
-    opener=None,
-    broken=False,
-    json_loads=None,
-    **json_loads_kwargs,
-)
+jsonl.load(source, *, opener=None, broken=False, cls=None, **kwargs)
 ```
 
 ### Parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `source` | `str`, `PathLike`, `URL`, `Request`, file-like | *(required)* | The JSON Lines source to read from |
-| `opener` | `Callable` or `None` | `None` | Custom function to open the file (not supported for URLs) |
-| `broken` | `bool` | `False` | If `True`, skip malformed lines and log a warning instead of raising an exception |
-| `json_loads` | `Callable` or `None` | `None` | Custom deserialization function. Defaults to `json.loads` |
-| `**json_loads_kwargs` | | | Additional keyword arguments passed to the deserialization function |
+| Parameter    | Type                                               | Default              | Description                                                                         |
+|--------------|----------------------------------------------------|----------------------|-------------------------------------------------------------------------------------|
+| `source`     | `str`, `PathLike`, `URL`, `Request`, file-like     | *(required)*         | The JSON Lines source to read from                                                  |
+| `opener`     | `Callable` or `None`                               | `None`               | Custom function to open the file (not supported for URLs)                           |
+| `broken`     | `bool`                                             | `False`              | If `True`, skip malformed lines and log a warning instead of raising an exception   |
+| `cls`        | `type[json.JSONDecoder]` or `Callable` or `None`   | `json.JSONDecoder`   | Custom decoder                                                                      |
+| `**kwargs`   |                                                    |                      | Keyword arguments used to pass the Custom decoder (`cls`)                           |
 
 ### Returns
 
@@ -34,11 +27,11 @@ jsonl.load(
 
 <a id="note-compression"></a>
 !!! note
-    Supported compression formats: **gzip (.gz), bzip2 (.bz2), xz (.xz), zst (.zst) (Python ≥ 3.14) **
+    Supported compression formats: `.gz`, `.bz2`, `.xz`, and `.zst` (*Python ≥ 3.14*)
 
     The compression format is resolved using two strategies:
 
-    1. **By file extension** — if the file has a recognized extension (`.gz`, `.bz2`, `.xz`, `.zst` (Python ≥ 3.14)), that format is used directly.
+    1. **By file extension** — if the file has a recognized extension (`.gz`, `.bz2`, `.xz`, `.zst` *Python ≥ 3.14* ), that format is used directly.
     2. **By magic numbers** — when the extension is not recognized, **jsonl** inspects the first bytes of the file
        ([magic numbers](https://en.wikipedia.org/wiki/List_of_file_signatures)) to auto-detect the compression format.
 
@@ -126,7 +119,7 @@ for item in jsonl.load(req):
 ### Handle broken lines
 
 !!! warning
-    When `broken=False` (the default), an exception is raised on the first malformed line.
+    When `broken=False` **(default)**, an exception is raised on the first malformed line.
     When `broken=True`, malformed lines are skipped and a warning is logged.
 
 ```python
@@ -153,6 +146,30 @@ WARNING:jsonl:Broken line at 2: Expecting ',' delimiter: line 2 column 1 (char 2
 
 ### Custom deserialization
 
+#### Using a custom JSON Decoder
+
+```python
+import json
+
+import jsonl
+
+
+class UpperDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, object_hook=self.object_hook, **kwargs)
+
+    def object_hook(self, obj):
+        return {k.upper(): v for k, v in obj.items()}
+
+
+data = [{"name": "Gilbert"}, {"name": "May"}]
+jsonl.dump(data, "file.jsonl")
+
+# Read using a custom decoder to convert all keys to uppercase.
+for item in jsonl.load("file.jsonl", cls=UpperDecoder):
+    print(item)
+```
+
 #### Using a third-party library
 
 [`orjson`](https://github.com/ijl/orjson) is a popular high-performance JSON library:
@@ -165,16 +182,16 @@ data = [
     {"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]},
     {"name": "May", "wins": []},
 ]
-
 jsonl.dump(data, "file.jsonl")
 
-for item in jsonl.load("file.jsonl", json_loads=orjson.loads):
+for item in jsonl.load("file.jsonl", cls=orjson.loads):
     print(item)
 ```
 
-#### Passing additional keyword arguments
+#### Passing keyword arguments
 
-Extra keyword arguments are forwarded to the deserialization function (by default, `json.loads`).
+Extra keyword arguments are forwarded to the `cls` decoder.
+
 For example, parse float values as `decimal.Decimal`:
 
 ```python
@@ -185,7 +202,6 @@ data = [
     {"name": "Gilbert", "wins_avg": 2.5},
     {"name": "May", "wins_avg": 3.75},
 ]
-
 jsonl.dump(data, "file.jsonl")
 
 for item in jsonl.load("file.jsonl", parse_float=decimal.Decimal):

--- a/docs/load_archive.md
+++ b/docs/load_archive.md
@@ -12,24 +12,24 @@ jsonl.load_archive(
     pwd=None,
     opener=None,
     broken=False,
-    json_loads=None,
+    cls=None,
     chunk_size=64 * 1024,
-    **json_loads_kwargs,
+    **kwargs,
 )
 ```
 
 ### Parameters
 
-| Parameter             | Type                                           | Default      | Description                                                                                                 |
-|-----------------------|------------------------------------------------|--------------|-------------------------------------------------------------------------------------------------------------|
-| `file`                | `str`, `PathLike`, `URL`, `Request`, file-like | *(required)* | Archive file to load from                                                                                   |
-| `pattern`             | `str`                                          | `"*.jsonl"`  | Unix shell-style wildcard pattern to filter filenames inside the archive                                    |
-| `pwd`                 | `bytes` or `None`                              | `None`       | Password to decrypt the archive (ZIP only)                                                                  |
-| `opener`              | `Callable` or `None`                           | `None`       | Custom function to open the file (not supported for URLs)                                                   |
-| `broken`              | `bool`                                         | `False`      | If `True`, skip malformed lines and log a warning                                                           |
-| `json_loads`          | `Callable` or `None`                           | `None`       | Custom deserialization function. Defaults to `json.loads`                                                   |
-| `chunk_size`          | `int`                                          | 64 * 1024    | The size (in bytes) of chunks when reading from a URL to avoid loading the entire file into memory at once. |
-| `**json_loads_kwargs` |                                                |              | Additional keyword arguments passed to the deserialization function                                         |
+| Parameter    | Type                                             | Default            | Description                                                                                                 |
+|--------------|--------------------------------------------------|--------------------|-------------------------------------------------------------------------------------------------------------|
+| `file`       | `str`, `PathLike`, `URL`, `Request`, file-like   | *(required)*       | Archive file to load from                                                                                   |
+| `pattern`    | `str`                                            | `"*.jsonl"`        | Unix shell-style wildcard pattern to filter filenames inside the archive                                    |
+| `pwd`        | `bytes` or `None`                                | `None`             | Password to decrypt the archive (ZIP only)                                                                  |
+| `opener`     | `Callable` or `None`                             | `None`             | Custom function to open the file (not supported for URLs)                                                   |
+| `broken`     | `bool`                                           | `False`            | If `True`, skip malformed lines and log a warning                                                           |
+| `chunk_size` | `int`                                            | 64 * 1024          | The size (in bytes) of chunks when reading from a URL to avoid loading the entire file into memory at once. |
+| `cls`        | `type[json.JSONDecoder]` or `Callable` or `None` | `json.JSONDecoder` | Custom decoder                                                                                              |
+| `**kwargs`   |                                                  |                    | Keyword arguments used to pass the Custom decoder (`cls`)                                                   |
 
 ### Returns
 
@@ -39,13 +39,14 @@ deserialized objects.
 ### Supported Archive Formats
 
 - **ZIP** archives (`.zip`)
-- **TAR** archives (`.tar`), including compressed variants: `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst` (Python ≥ 3.14) )
+- **TAR** archives (`.tar`), including compressed variants: `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst` (Python ≥ 3.14)
 
 ### Key Features
 
 - Load from local files or remote URLs
 - Filter files inside the archive using [Unix shell-style wildcards](https://docs.python.org/3/library/fnmatch.html)
-- Support for compressed `.jsonl` files inside the archive (e.g., `.jsonl.gz`, `.jsonl.bz2`, `.jsonl.xz`, `.jsonl.zst` (Python ≥ 3.14) ).
+- Support for compressed `.jsonl` files inside the archive (e.g., `.jsonl.gz`, `.jsonl.bz2`, `.jsonl.xz`, `.jsonl.zst` (
+  Python ≥ 3.14) ).
   Check [compression detection](load.md#note-compression) for details.
 - ZIP archives with password protection
 - Graceful handling of malformed lines via the `broken` parameter

--- a/jsonl.py
+++ b/jsonl.py
@@ -265,7 +265,7 @@ def _get_decode(cls, kwargs):
     elif is_subclass(cls, json.JSONDecoder):
         decode = cls(**kwargs).decode
     else:
-        decode = cls(**kwargs)
+        decode = functools.partial(cls, **kwargs)
     return decode
 
 # ---------------------------------- Public API ----------------------------------

--- a/jsonl.py
+++ b/jsonl.py
@@ -35,7 +35,7 @@ import zipfile
 try:
     from compression import zstd
 except ImportError:
-    zstd = None
+    zstd = None  # Python < 3.14
 
 # ---------------------------------- Internal variables ----------------------------------
 
@@ -234,7 +234,7 @@ def _iterfind_tar_members(name_or_obj, pattern, /):
                     yield file
 
 
-def is_subclass(o, klass):
+def _issubclass(o, klass):
     try:
         return issubclass(o, klass)
     except TypeError:
@@ -242,13 +242,11 @@ def is_subclass(o, klass):
 
 
 def _get_encode(cls, kwargs):
-    # return _default_encode if not (cls or kwargs) else (cls or json.JSONEncoder)(**kwargs).encode
-
     if not (cls or kwargs):
         encode = _default_encode
     elif not cls:
         encode = json.JSONEncoder(**kwargs)
-    elif is_subclass(cls, json.JSONEncoder):
+    elif _issubclass(cls, json.JSONEncoder):
         encode = cls(**kwargs).encode
     else:
         encode = functools.partial(cls, **kwargs)
@@ -256,13 +254,11 @@ def _get_encode(cls, kwargs):
 
 
 def _get_decode(cls, kwargs):
-    # return _default_decode if not (cls or kwargs) else (cls or json.JSONDecoder)(**kwargs).decode
-
     if not (cls or kwargs):
         decode = _default_decode
     elif not cls:
         decode = json.JSONDecoder(** kwargs)
-    elif is_subclass(cls, json.JSONDecoder):
+    elif _issubclass(cls, json.JSONDecoder):
         decode = cls(**kwargs).decode
     else:
         decode = functools.partial(cls, **kwargs)

--- a/jsonl.py
+++ b/jsonl.py
@@ -79,6 +79,7 @@ else:
     _openers[ext_zst] = zstd.open
     _archive_formats["tar.zst"] = "zstdtar"
 
+
 # ---------------------------------- Internal utils ----------------------------------
 
 
@@ -233,19 +234,38 @@ def _iterfind_tar_members(name_or_obj, pattern, /):
                     yield file
 
 
+def is_subclass(o, klass):
+    try:
+        return issubclass(o, klass)
+    except TypeError:
+        return False
+
+
 def _get_encode(cls, kwargs):
+    # return _default_encode if not (cls or kwargs) else (cls or json.JSONEncoder)(**kwargs).encode
+
     if not (cls or kwargs):
         encode = _default_encode
+    elif not cls:
+        encode = json.JSONEncoder(**kwargs)
+    elif is_subclass(cls, json.JSONEncoder):
+        encode = cls(**kwargs).encode
     else:
-        encode = (cls or json.JSONEncoder)(**kwargs).encode
+        encode = functools.partial(cls, **kwargs)
     return encode
 
 
 def _get_decode(cls, kwargs):
+    # return _default_decode if not (cls or kwargs) else (cls or json.JSONDecoder)(**kwargs).decode
+
     if not (cls or kwargs):
         decode = _default_decode
+    elif not cls:
+        decode = json.JSONDecoder(** kwargs)
+    elif is_subclass(cls, json.JSONDecoder):
+        decode = cls(**kwargs).decode
     else:
-        decode = (cls or json.JSONDecoder)(**kwargs).decode
+        decode = cls(**kwargs)
     return decode
 
 # ---------------------------------- Public API ----------------------------------
@@ -298,8 +318,11 @@ def dump(iterable, file, /, *, opener=None, text_mode=True, cls=None, **kwargs):
         * If a file object is provided, the `writelines` or `write` methods will be used to write the string data.
     :param Optional[Callable] opener: Custom function to open the file if a filename is provided.
     :param bool text_mode: If false, write bytes to the file.
-    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
-    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
+
+    :param Optional[type[json.JSONEncoder] | Callable[..., Any]] cls: Custom encoder (defaults to `json.JSONEncoder`)
+        - JSONEncoder subclass
+        - Callable accepting arbitrary arguments and returning an encoded object
+    :param Unpack[dict] kwargs: keyword arguments used to pass the Custom encoder (`cls`).
 
     :raises ValueError: If the file object is missing the `writelines` and `write` methods.
     """
@@ -328,8 +351,11 @@ def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, cls=
     :param Optional[Callable] opener: Custom function to open the given file paths.
     :param bool text_mode: If false, write bytes to the file.
     :param bool dump_if_empty: If false, don't create an empty jsonlines file.
-    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
-    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
+
+    :param Optional[type[json.JSONEncoder] | Callable[..., Any]] cls: Custom encoder (defaults to `json.JSONEncoder`)
+        - JSONEncoder subclass
+        - Callable accepting arbitrary arguments and returning an encoded object
+    :param Unpack[dict] kwargs: keyword arguments used to pass the Custom encoder (`cls`).
     """
 
     def get_writer(dst):
@@ -382,8 +408,12 @@ def load(source, /, *, opener=None, broken=False, cls=None, **kwargs):
         For more details, see: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen
     :param Optional[Callable] opener: Custom function to open the file if a filename is provided.
     :param bool broken: If true, skip broken lines (only logging a warning).
-    :param Optional[Callable] cls: Custom `json.JSONDecoder` subclass (defaults to `json.JSONDecoder`).
-    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONDecoder`.
+
+    :param Optional[type[json.JSONDecoder] | Callable[..., Any]] cls: Custom decoder (defaults to `json.JSONDecoder`)
+        - JSONDecoder subclass
+        - Callable accepting arbitrary arguments and returning a decoded object
+    :param Unpack[dict] kwargs: keyword arguments used to pass the Custom decoder (`cls`).
+
     :rtype: Iterator[Any]
     """
 
@@ -439,8 +469,12 @@ def load_archive(
     :param int chunk_size:
         The size (in bytes) of chunks when reading from a URL to avoid loading the entire file into memory at once.
         Default is 64 KB (64 * 1024 bytes).
-    :param Optional[Callable] cls: Custom `json.JSONDecoder` subclass (defaults to `json.JSONDecoder`).
-    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONDecoder`.
+
+    :param Optional[type[json.JSONDecoder] | Callable[..., Any]] cls: Custom decoder (defaults to `json.JSONDecoder`)
+        - JSONDecoder subclass
+        - Callable accepting arbitrary arguments and returning a decoded object
+    :param Unpack[dict] kwargs: keyword arguments used to pass the Custom decoder (`cls`).
+
     :rtype: Iterator[tuple[str, Iterator[Any]]]
     """
 
@@ -499,8 +533,10 @@ def dump_archive(
     :param bool text_mode: If false, write bytes to the file.
     :param bool dump_if_empty: If false, don't create an empty jsonlines file nor an empty archive.
 
-    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
-    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
+    :param Optional[type[json.JSONEncoder] | Callable[..., Any]] cls: Custom encoder (defaults to `json.JSONEncoder`)
+        - JSONEncoder subclass
+        - Callable accepting arbitrary arguments and returning an encoded object
+    :param Unpack[dict] kwargs: keyword arguments used to pass the Custom encoder (`cls`).
 
     :raises ValueError: If a filepath in `items_by_relpath` is absolute, or if the archive extension is unsupported.
     :return: Path to the created archive file, or `None` if no items were dumped and `dump_if_empty` is `False`.

--- a/jsonl.py
+++ b/jsonl.py
@@ -37,12 +37,16 @@ try:
 except ImportError:
     zstd = None
 
+# ---------------------------------- Internal variables ----------------------------------
+
 _utf_8 = "utf-8"
 _new_line = "\n"
 _new_line_bytes = b"\n"
 
-_default_json_dumps = functools.partial(json.dumps, ensure_ascii=False)  # result can include non-ASCII characters
-_default_json_loads = json.loads
+_default_decode = json.JSONDecoder().decode
+_default_encode = json.JSONEncoder(
+    ensure_ascii=False,  # result can include non-ASCII characters
+).encode
 
 _logger = logging.getLogger(__name__)
 _logger.addHandler(logging.NullHandler())
@@ -74,6 +78,8 @@ else:
     extensions.add(ext_zst)
     _openers[ext_zst] = zstd.open
     _archive_formats["tar.zst"] = "zstdtar"
+
+# ---------------------------------- Internal utils ----------------------------------
 
 
 def _get_fileobj_extension(fileobj, /):
@@ -227,45 +233,63 @@ def _iterfind_tar_members(name_or_obj, pattern, /):
                     yield file
 
 
-def dumper(iterable, /, *, text_mode=True, json_dumps=None, **json_dumps_kwargs):
+def _get_encode(cls, kwargs):
+    if not (cls or kwargs):
+        encode = _default_encode
+    else:
+        encode = (cls or json.JSONEncoder)(**kwargs).encode
+    return encode
+
+
+def _get_decode(cls, kwargs):
+    if not (cls or kwargs):
+        decode = _default_decode
+    else:
+        decode = (cls or json.JSONDecoder)(**kwargs).decode
+    return decode
+
+# ---------------------------------- Public API ----------------------------------
+
+
+def dumper(iterable, /, *, text_mode=True, cls=None, **kwargs):
     """Dump an iterable of objects into JSON Lines format."""
 
-    serialize = functools.partial(json_dumps or _default_json_dumps, **json_dumps_kwargs)
+    encode = _get_encode(cls, kwargs)
     for obj in iterable:
-        value = serialize(obj)  # can be bytes, like "orjson.dumps".
+        value = encode(obj)  # can be bytes, like "orjson.dumps".
         yield _get_line(value, text_mode)
 
 
-def loader(stream, broken, /, *, json_loads=None, **json_loads_kwargs):
+def loader(stream, broken, /, *, cls=None, **kwargs):
     """Load a JSON Lines formatted stream into an object iterator."""
 
-    deserialize = functools.partial(json_loads or _default_json_loads, **json_loads_kwargs)
+    decode = _get_decode(cls, kwargs)
     is_bytes = None
     for lineno, line in enumerate(stream, start=1):
         if is_bytes is None:  # Avoid "isinstance" check on every line after the first one.
             is_bytes = isinstance(line, bytes)
         try:
-            yield deserialize(line.decode(_utf_8) if is_bytes else line)
+            yield decode(line.decode(_utf_8) if is_bytes else line)
         except Exception as e:
             _logger.warning("Broken line at %s: %s", lineno, e)
             if not broken:
                 raise
 
 
-def dumps(iterable, /, *, json_dumps=None, **json_dumps_kwargs):
+def dumps(iterable, /, *, cls=None, **kwargs):
     """
     Serialize an iterable into a JSON Lines formatted string.
 
     :param Iterable[Any] iterable: Iterable of objects
-    :param Optional[Callable] json_dumps: Custom function to serialize objects. By default, `json.dumps` is used.
-    :param Unpack[dict] json_dumps_kwargs: Additional keywords to pass to `dumps` of `json` provider
+    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
     :rtype: str
     """
 
-    return "".join(dumper(iterable, text_mode=True, json_dumps=json_dumps, **json_dumps_kwargs))
+    return "".join(dumper(iterable, text_mode=True, cls=cls, **kwargs))
 
 
-def dump(iterable, file, /, *, opener=None, text_mode=True, json_dumps=None, **json_dumps_kwargs):
+def dump(iterable, file, /, *, opener=None, text_mode=True, cls=None, **kwargs):
     """
     Dump an iterable to a JSON Lines file.
 
@@ -274,12 +298,13 @@ def dump(iterable, file, /, *, opener=None, text_mode=True, json_dumps=None, **j
         * If a file object is provided, the `writelines` or `write` methods will be used to write the string data.
     :param Optional[Callable] opener: Custom function to open the file if a filename is provided.
     :param bool text_mode: If false, write bytes to the file.
-    :param Optional[Callable] json_dumps: Custom function to serialize objects. By default, `json.dumps` is used.
-    :param Unpack[dict] json_dumps_kwargs: Additional keywords to pass to `dumps` of `json` provider
+    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
+
     :raises ValueError: If the file object is missing the `writelines` and `write` methods.
     """
 
-    lines = dumper(iterable, text_mode=text_mode, json_dumps=json_dumps, **json_dumps_kwargs)
+    lines = dumper(iterable, text_mode=text_mode, cls=cls, **kwargs)
     if isinstance(file, (str, os.PathLike)):
         file = os.fspath(file)
         fd_mode = "wt" if text_mode else "wb"
@@ -295,7 +320,7 @@ def dump(iterable, file, /, *, opener=None, text_mode=True, json_dumps=None, **j
         raise ValueError("Invalid file object, missing `writelines` and `write` methods.")
 
 
-def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, json_dumps=None, **json_dumps_kwargs):
+def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, cls=None, **kwargs):
     """
     Incrementally dumps multiple iterables into the specified jsonlines files, effectively reducing memory consumption.
 
@@ -303,8 +328,8 @@ def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, json
     :param Optional[Callable] opener: Custom function to open the given file paths.
     :param bool text_mode: If false, write bytes to the file.
     :param bool dump_if_empty: If false, don't create an empty jsonlines file.
-    :param Optional[Callable] json_dumps: Custom function to serialize objects. By default, `json.dumps` is used.
-    :param Unpack[dict] json_dumps_kwargs: Additional keywords to pass to `dumps` of `json` provider
+    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
     """
 
     def get_writer(dst):
@@ -316,7 +341,7 @@ def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, json
                 while True:
                     obj = yield
                     nothing = False
-                    fd.write(_get_line(encoder(obj), text_mode))
+                    fd.write(_get_line(encode(obj), text_mode))
             except GeneratorExit:
                 # Flush compressor buffers before closing the generator to
                 # ensure a valid end-of-stream marker (required for .gz/.xz/.zst in Python 3.14+)
@@ -325,7 +350,7 @@ def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, json
         if nothing and not dump_if_empty:
             os.unlink(dst)
 
-    encoder = functools.partial(json_dumps or _default_json_dumps, **json_dumps_kwargs)
+    encode = _get_encode(cls, kwargs)
     writers = {}
     try:
         for xpath, iterable in paths:
@@ -344,7 +369,7 @@ def dump_fork(paths, /, *, opener=None, text_mode=True, dump_if_empty=True, json
             writer.close()
 
 
-def load(source, /, *, opener=None, broken=False, json_loads=None, **json_loads_kwargs):
+def load(source, /, *, opener=None, broken=False, cls=None, **kwargs):
     """
     Deserialize a UTF-8 encoded JSON Lines source—such as a filename, URL, or file-like object—into an object iterator.
 
@@ -357,8 +382,8 @@ def load(source, /, *, opener=None, broken=False, json_loads=None, **json_loads_
         For more details, see: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen
     :param Optional[Callable] opener: Custom function to open the file if a filename is provided.
     :param bool broken: If true, skip broken lines (only logging a warning).
-    :param Optional[Callable] json_loads: Custom function to deserialize JSON strings. By default, `json.loads` is used.
-    :param Unpack[dict] json_loads_kwargs: Additional keywords to pass to `loads` of `json` provider.
+    :param Optional[Callable] cls: Custom `json.JSONDecoder` subclass (defaults to `json.JSONDecoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONDecoder`.
     :rtype: Iterator[Any]
     """
 
@@ -370,16 +395,16 @@ def load(source, /, *, opener=None, broken=False, json_loads=None, **json_loads_
             charset = fd.headers.get_content_charset(failobj=_utf_8)
             # Wrap the file descriptor to handle text encoding.
             with io.TextIOWrapper(fd, encoding=charset) as stream:
-                yield from loader(stream, broken, json_loads=json_loads, **json_loads_kwargs)
+                yield from loader(stream, broken, cls=cls, **kwargs)
     # Filename handling
     elif isinstance(source, (str, os.PathLike)):
         filename = source if isinstance(source, str) else os.fspath(source)  # Ensure it's a string path
         openhook = opener or _xopen
         with openhook(filename, mode="rb", encoding=None) as fd:
-            yield from loader(fd, broken, json_loads=json_loads, **json_loads_kwargs)
+            yield from loader(fd, broken, cls=cls, **kwargs)
     # File-like object handling
     else:
-        yield from loader(source, broken, json_loads=json_loads, **json_loads_kwargs)
+        yield from loader(source, broken, cls=cls, **kwargs)
 
 
 def load_archive(
@@ -390,14 +415,14 @@ def load_archive(
     pwd=None,
     opener=None,
     broken=False,
-    json_loads=None,
     chunk_size=64 * 1024,
-    **json_loads_kwargs,
+    cls=None,
+    **kwargs,
 ):
     """
     Load JSON Lines files from an archive (zip or tar) matching a specific pattern.
 
-    Tar archives can be compressed with gzip, bzip2, or xz. (e.g., `.tar.gz`, `.tar.bz2`, `.tar.xz`).
+    Tar archives can be compressed with gzip, bzip2, xz or zst (Python +3.14). (e.g., `.tar.gz`, `.tar.bz2`, `.tar.xz`).
 
     :param str | bytes | os.PathLike | urllib.request.Request | Any file: Archive file to load.
         If a URL or `urllib.request.Request` object is provided, the file will be retrieved
@@ -411,11 +436,11 @@ def load_archive(
     :param Optional[bytes] pwd: The password to decrypt the archive, if applicable.
     :param Optional[Callable] opener: Custom function to open the file if a filename is provided.
     :param bool broken: If true, skip broken lines (only logging a warning).
-    :param Optional[Callable] json_loads: Custom function to deserialize JSON strings. By default, `json.loads` is used.
     :param int chunk_size:
         The size (in bytes) of chunks when reading from a URL to avoid loading the entire file into memory at once.
         Default is 64 KB (64 * 1024 bytes).
-    :param Unpack[dict] json_loads_kwargs: Additional keywords to pass to `loads` of `json` provider.
+    :param Optional[Callable] cls: Custom `json.JSONDecoder` subclass (defaults to `json.JSONDecoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONDecoder`.
     :rtype: Iterator[tuple[str, Iterator[Any]]]
     """
 
@@ -443,7 +468,7 @@ def load_archive(
         for member in members:
             filename = member.name
             with _xfile(filename, member) as fp:
-                it = load(fp, opener=opener, broken=broken, json_loads=json_loads, **json_loads_kwargs)
+                it = load(fp, opener=opener, broken=broken, cls=cls, **kwargs)
                 yield (filename, it)
 
 
@@ -455,14 +480,15 @@ def dump_archive(
     opener=None,
     text_mode=True,
     dump_if_empty=True,
-    json_dumps=None,
-    **json_dumps_kwargs,
+    cls=None,
+    **kwargs,
 ):
     """
     Dump multiple JSON Lines items into an archive file (zip or tar) with the specified path.
 
     - If the archive already exists on the given path, it will be overwritten.
-    - Supports TAR compression with gzip (`.tar.gz`), bzip2 (`.tar.bz2`), or xz (`.tar.xz`).
+    - Supports TAR compression with gzip (`.tar.gz`), bzip2 (`.tar.bz2`), xz (`.tar.xz`),
+      or zst (`.tar.zst`) (Python +3.14)
 
     :param str path: Destination path for the archive file.
     :param Iterable[tuple[str | os.PathLike, Iterable[Any]]] data:
@@ -472,8 +498,9 @@ def dump_archive(
     :param Optional[Callable] opener: Custom function to open the given file paths.
     :param bool text_mode: If false, write bytes to the file.
     :param bool dump_if_empty: If false, don't create an empty jsonlines file nor an empty archive.
-    :param Optional[Callable] json_dumps: Custom function to serialize objects. By default, `json.dumps` is used.
-    :param Unpack[dict] json_dumps_kwargs: Additional keywords to pass to `dumps` of `json` provider
+
+    :param Optional[Callable] cls: Custom `json.JSONEncoder` subclass (defaults to `json.JSONEncoder`).
+    :param Unpack[dict] kwargs: keyword arguments used to configure the `JSONEncoder`.
 
     :raises ValueError: If a filepath in `items_by_relpath` is absolute, or if the archive extension is unsupported.
     :return: Path to the created archive file, or `None` if no items were dumped and `dump_if_empty` is `False`.
@@ -500,8 +527,8 @@ def dump_archive(
             opener=opener,
             text_mode=text_mode,
             dump_if_empty=dump_if_empty,
-            json_dumps=json_dumps,
-            **json_dumps_kwargs,
+            cls=cls,
+            **kwargs,
         )
         if dump_if_empty or os.listdir(tmpdir):
             # Create the archive from the temporary directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,34 @@ import pathlib
 import tempfile
 import threading
 
-import orjson
 import pytest
-import ujson
 
 import jsonl
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+
+
+class CustomDecoder(json.JSONDecoder):
+    pass
+
+
+class CustomEncoder(json.JSONEncoder):
+    pass
+
+
+class UpperDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, object_hook=self.object_hook, **kwargs)
+
+    def object_hook(self, obj):
+        return {k.upper(): v for k, v in obj.items()}
+
+
+class UpperEncoder(json.JSONEncoder):
+    def encode(self, obj):
+        if isinstance(obj, dict):
+            obj = {k.upper(): v for k, v in obj.items()}
+        return super().encode(obj)
 
 
 @contextlib.contextmanager
@@ -94,6 +115,11 @@ def filepath(tmp_dir, filename):
     return str(tmp_dir / filename)
 
 
-@pytest.fixture(scope="package", params=(orjson.loads, ujson.loads, json.loads, None))
-def json_loads(request):
+@pytest.fixture(scope="package", params=(json.JSONDecoder, CustomDecoder, None))
+def json_decoder(request):
+    return request.param
+
+
+@pytest.fixture(scope="package", params=(json.JSONEncoder, CustomEncoder, None))
+def json_encoder(request):
     return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,21 +25,6 @@ class CustomEncoder(json.JSONEncoder):
     pass
 
 
-class UpperDecoder(json.JSONDecoder):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, object_hook=self.object_hook, **kwargs)
-
-    def object_hook(self, obj):
-        return {k.upper(): v for k, v in obj.items()}
-
-
-class UpperEncoder(json.JSONEncoder):
-    def encode(self, obj):
-        if isinstance(obj, dict):
-            obj = {k.upper(): v for k, v in obj.items()}
-        return super().encode(obj)
-
-
 @contextlib.contextmanager
 def manage_http_server(directory):
     """

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,7 +7,9 @@ import os
 import pathlib
 import tempfile
 
+import orjson
 import pytest
+import ujson
 
 import jsonl
 import tests
@@ -44,6 +46,8 @@ def test_invalid_object():
     [
         (json.JSONEncoder, {"ensure_ascii": False}, tests.string_data),
         (None, {}, tests.string_data),
+        (orjson.dumps, {}, tests.compacted_string_data),
+        (ujson.dumps, {"ensure_ascii": False}, tests.compacted_string_data),
     ],
 )
 def test_filepath(filepath, cls, kwargs, expected, pathlike):

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,9 +7,7 @@ import os
 import pathlib
 import tempfile
 
-import orjson
 import pytest
-import ujson
 
 import jsonl
 import tests
@@ -42,17 +40,15 @@ def test_invalid_object():
 
 
 @pytest.mark.parametrize(
-    "json_dumps, json_dumps_kwargs, expected",
+    "cls, kwargs, expected",
     [
-        (orjson.dumps, {}, tests.compacted_string_data),
-        (ujson.dumps, {"ensure_ascii": False}, tests.compacted_string_data),
-        (json.dumps, {"ensure_ascii": False}, tests.string_data),
+        (json.JSONEncoder, {"ensure_ascii": False}, tests.string_data),
         (None, {}, tests.string_data),
     ],
 )
-def test_filepath(filepath, json_dumps, json_dumps_kwargs, expected, pathlike):
+def test_filepath(filepath, cls, kwargs, expected, pathlike):
     filepath = pathlib.Path(filepath) if pathlike else filepath
-    jsonl.dump(iter(tests.data), filepath, json_dumps=json_dumps, **json_dumps_kwargs)
+    jsonl.dump(iter(tests.data), filepath, cls=cls, **kwargs)
     result = tests.read_text(filepath)
     assert result == expected
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -89,3 +89,16 @@ def test_dump_given_custom_file_writelines_method():
     file = CustomFile()
     jsonl.dump(tests.data, file)
     assert file.content == tests.string_data
+
+
+def test_dump_custom_encoder():
+    class UpperEncoder(json.JSONEncoder):
+        def encode(self, obj):
+            if isinstance(obj, dict):
+                obj = {k.upper(): v for k, v in obj.items()}
+            return super().encode(obj)
+
+    with contextlib.closing(io.StringIO()) as fp:
+        jsonl.dump(({"key": "val"},), fp, cls=UpperEncoder)
+
+        assert fp.getvalue() == '{"KEY": "val"}\n'

--- a/tests/test_dump_fork.py
+++ b/tests/test_dump_fork.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
+import json
 import os
 import pathlib
 import tempfile
 
 import pytest
-import ujson
 
 import jsonl
 import tests
 
 
 @pytest.mark.parametrize(
-    "json_dumps, json_dumps_kwargs",
+    "cls, kwargs",
     [
-        (ujson.dumps, {"ensure_ascii": False, "separators": (", ", ": ")}),
+        (json.JSONEncoder, {"ensure_ascii": False, "separators": (", ", ": ")}),
         (None, {}),
     ],
 )
 @pytest.mark.parametrize("text_mode", (True, False))
-def test_iter_data(file_extension, pathlike, text_mode, json_dumps, json_dumps_kwargs):
+def test_iter_data(file_extension, pathlike, text_mode, cls, kwargs):
     with tempfile.TemporaryDirectory() as tmp:
         foo_path = os.path.join(tmp, f"foo{file_extension}")
         var_path = os.path.join(tmp, f"var{file_extension}")
@@ -35,7 +35,7 @@ def test_iter_data(file_extension, pathlike, text_mode, json_dumps, json_dumps_k
             (baz_path, iter(())),
         )
 
-        jsonl.dump_fork(iter(path_items), text_mode=text_mode, json_dumps=json_dumps, **json_dumps_kwargs)
+        jsonl.dump_fork(iter(path_items), text_mode=text_mode, cls=cls, **kwargs)
 
         assert tests.read_text(foo_path) == '{"foo": 1}\n{"ño": 2}\n{"extra": true}\n'
         assert tests.read_text(var_path) == '{"foo": 1}\n{"ño": 2}\n'

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -57,7 +57,7 @@ def test_memory_file(iofile):
 
 
 @pytest.mark.parametrize("mode", ("rt", "rb"))
-def test_opened_file(filepath, mode, json_loads):
+def test_opened_file(filepath, mode, json_decoder):
     expected = tuple(tests.data)
     # Prepare a file with JSON lines
     with jsonl._xopen(filepath, mode="wb") as fp:  # write into a binary file
@@ -65,27 +65,27 @@ def test_opened_file(filepath, mode, json_loads):
         fp.write(content)
     # Load the file in given mode
     with jsonl._xopen(filepath, mode=mode) as fp:
-        result = tuple(jsonl.load(fp, json_loads=json_loads))
+        result = tuple(jsonl.load(fp, cls=json_decoder))
     assert result == expected
 
 
 @pytest.mark.parametrize("pathlike", (True, False))
-def test_filepath(filepath, json_loads, pathlike):
+def test_filepath(filepath, json_decoder, pathlike):
     filepath = pathlib.Path(filepath) if pathlike else filepath
     expected = tuple(tests.data)
     tests.write_text(filepath, content=tests.string_data)
-    result = tuple(jsonl.load(filepath, json_loads=json_loads))
+    result = tuple(jsonl.load(filepath, cls=json_decoder))
     assert result == expected
 
 
-def test_filepath_unknown_extension_but_detected_by_signature(filepath, json_loads):
+def test_filepath_unknown_extension_but_detected_by_signature(filepath, json_decoder):
     expected = tuple(tests.data)
     tests.write_text(filepath, content=tests.string_data)  # Write compressed data first
     # Rename to have an unknown extension after writing valid data
     new_filepath = filepath + ".unknown"
     os.rename(filepath, new_filepath)
 
-    result = tuple(jsonl.load(new_filepath, json_loads=json_loads))
+    result = tuple(jsonl.load(new_filepath, cls=json_decoder))
     assert result == expected
 
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -123,3 +123,16 @@ def test_http_server_url(http_server):
     url = http_server + "foo.jsonl"
     data = list(jsonl.load(url))
     assert data == tests.data
+
+
+def test_load_custom_decoder():
+    class LowerDecoder(json.JSONDecoder):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, object_hook=self.object_hook, **kwargs)
+
+        def object_hook(self, obj):
+            return {k.lower(): v for k, v in obj.items()}
+
+    with contextlib.closing(io.StringIO('{"KEY": "val"}\n')) as fd:
+        data = list(jsonl.load(fd, cls=LowerDecoder))
+        assert data == [{"key": "val"}]


### PR DESCRIPTION
TODO:

- [ ]  Update README
- [ ]  Update doc site
- [ ]  Add more tests to validate custom JSONEncoder and JSONDEcoder that override the standard behavior
- [ ] Consider alternatives to ensure that the jsonl remains compatible with plugins and can be used, for example, with `orjson`



