### PR TITLE
fix: `json.JSONEncoder`/`json.JSONDecoder` is not callable

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -245,7 +245,7 @@ def _get_encode(cls, kwargs):
     if not (cls or kwargs):
         encode = _default_encode
     elif not cls:
-        encode = json.JSONEncoder(**kwargs)
+        encode = json.JSONEncoder(**kwargs).encode
     elif _issubclass(cls, json.JSONEncoder):
         encode = cls(**kwargs).encode
     else:
@@ -257,7 +257,7 @@ def _get_decode(cls, kwargs):
     if not (cls or kwargs):
         decode = _default_decode
     elif not cls:
-        decode = json.JSONDecoder(** kwargs)
+        decode = json.JSONDecoder(**kwargs).decode
     elif _issubclass(cls, json.JSONDecoder):
         decode = cls(**kwargs).decode
     else:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -46,6 +46,7 @@ def test_invalid_object():
     [
         (json.JSONEncoder, {"ensure_ascii": False}, tests.string_data),
         (None, {}, tests.string_data),
+        (None, {"ensure_ascii": False}, tests.string_data),
         (orjson.dumps, {}, tests.compacted_string_data),
         (ujson.dumps, {"ensure_ascii": False}, tests.compacted_string_data),
     ],


### PR DESCRIPTION
fixes #22